### PR TITLE
Fix readme example with Swiftmailer 6.x API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require hexanet/swiftmailer-image-embed
 ```php
 use Hexanet\Swiftmailer\ImageEmbedPlugin;
 
-$mailer = Swift_Mailer::newInstance();
+$mailer = new Swift_Mailer($yourTransport);
 
 $mailer->registerPlugin(new ImageEmbedPlugin());
 ```


### PR DESCRIPTION
Method `newInstance` has been removed.

See https://github.com/swiftmailer/swiftmailer/blob/master/CHANGES#L24.