### PR TITLE
Allow to set base path for the image lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ $mailer = new Swift_Mailer($yourTransport);
 $mailer->registerPlugin(new ImageEmbedPlugin());
 ```
 
+or for symfony in your services.yml:
+```yml
+    hexanet.swiftmailer.image_embed_plugin:
+        class: Hexanet\Swiftmailer\ImageEmbedPlugin
+        tags:
+            - { name: swiftmailer.default.plugin }
+        arguments: ['%kernel.root_dir%/../web/']
+```
+
+The arguments are optional.
+
 ## Credits
 
 Developed by the [Dev Team](http://teamdev.hexanet.fr) of [Hexanet](http://www.hexanet.fr/).

--- a/src/ImageEmbedPlugin.php
+++ b/src/ImageEmbedPlugin.php
@@ -11,6 +11,18 @@ use Swift_Mime_SimpleMessage;
 class ImageEmbedPlugin implements Swift_Events_SendListener
 {
 
+    private $basePath = '';
+
+    /**
+     * ImageEmbedPlugin constructor.
+     *
+     * @param string $basePath
+     */
+    public function __construct($basePath = '')
+    {
+        $this->basePath = $basePath;
+    }
+
     /**
      * @param Swift_Events_SendEvent $event
      */
@@ -60,7 +72,7 @@ class ImageEmbedPlugin implements Swift_Events_SendListener
              */
             if (strpos($src, 'cid:') === false) {
 
-                $entity = Swift_Image::fromPath($src);
+                $entity = \Swift_Image::fromPath($this->basePath . $src);
                 $message->setChildren(
                     array_merge($message->getChildren(), [$entity])
                 );


### PR DESCRIPTION
if you want to use {{ asset(...) }} or something similar in your templates you will get a relative path from the `web` directory. Which then can't be resolved as `Swift_Image::fromPath` uses the project root as base. With this the basepath can be configured which gives more flexibility.