### PR TITLE
Add PHP 7.3 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 cache:
   directories:


### PR DESCRIPTION
The release of PHP 7.3 is near: https://wiki.php.net/todo/php73. 