### PR TITLE
return utf8_decode($dom->saveHTML($dom->documentElement));

### DIFF
--- a/src/ImageEmbedPlugin.php
+++ b/src/ImageEmbedPlugin.php
@@ -81,7 +81,7 @@ class ImageEmbedPlugin implements Swift_Events_SendListener
             }
         }
 
-        return $dom->saveHTML();
+        return utf8_decode($dom->saveHTML($dom->documentElement));
     }
 
     protected function isUrl(string $path) : bool


### PR DESCRIPTION
As DOMDocument works very badly with UTF8 encoded HTML, a fix is needed to preserve non-ANSI chars.

Fix from here: https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly